### PR TITLE
Fix return type of array to correct Buffer in CodecWithXrpAlphabet->decodeNodePublic()

### DIFF
--- a/src/Core/RippleAddressCodec/CodecWithXrpAlphabet.php
+++ b/src/Core/RippleAddressCodec/CodecWithXrpAlphabet.php
@@ -80,7 +80,7 @@ class CodecWithXrpAlphabet extends Codec
             'versions' => [self::NODE_PUBLIC],
             'expectedLength' => 33
         ];
-        return $this->decode($base58string, $options)['bytes'];
+        return Buffer::from($this->decode($base58string, $options)['bytes']);
     }
 
     public function encodeAccountPublic(Buffer $bytes): string


### PR DESCRIPTION
Fix return type of array to correct Buffer in CodecWithXrpAlphabet->decodeNodePublic()