### PR TITLE
Make JsonRpcClient timeout configurable

### DIFF
--- a/src/Client/JsonRpcClient.php
+++ b/src/Client/JsonRpcClient.php
@@ -45,12 +45,11 @@ class JsonRpcClient
 
     private string $maxFeeXrp;
 
-    private float $timeout = 3.0;
-
     public function __construct(
         string $connectionUrl,
         ?float $feeCushion = null,
-        ?string $maxFeeXrp  =null
+        ?string $maxFeeXrp = null,
+        ?float $timeout = 3.0
     ) {
         $this->connectionUrl = $connectionUrl;
 
@@ -64,7 +63,7 @@ class JsonRpcClient
             [
                 'base_uri' => $this->connectionUrl,
                 'handler' => $stack,
-                'timeout' => $this->timeout,
+                'timeout' => $timeout,
             ]
         );
     }


### PR DESCRIPTION
Since the 3.0 second timeout was throwing errors even though my transaction actually completed on the blockchain,  I made the value an optional parameter in case users want a longer value or to disable it using `0`. 

https://docs.guzzlephp.org/en/stable/request-options.html#timeout
