### PR TITLE
Merge bump-buffer-version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
     "php-ds/php-ds": "^1.4",
     "simplito/elliptic-php": "^1.0.12",
     "simplito/bn-php": "^1.1.4",
-    "hardcastle/buffer": "^0.2.0",
+    "hardcastle/buffer": "^1.0.0",
     "vlucas/phpdotenv": "^5.6"
   },
   "require-dev": {

--- a/src/Core/CoreUtilities.php
+++ b/src/Core/CoreUtilities.php
@@ -94,7 +94,7 @@ class CoreUtilities
         $_this = self::getInstance();
 
         if (is_string($publicKey)) {
-            $publicKey = Buffer::from($publicKey);
+            $publicKey = Buffer::from($publicKey, 'hex');
         }
 
         $publicKeyHash = MathUtilities::computePublicKeyHash($publicKey);

--- a/src/Core/Ctid.php
+++ b/src/Core/Ctid.php
@@ -29,7 +29,7 @@ class Ctid
      */
     public function __construct(string $ctidAsHex)
     {
-        $this->internal = Buffer::from($ctidAsHex);
+        $this->internal = Buffer::from($ctidAsHex, 'hex');
     }
 
     /**

--- a/src/Core/MathUtilities.php
+++ b/src/Core/MathUtilities.php
@@ -26,25 +26,23 @@ class MathUtilities
 
     public static function computePublicKeyHash(Buffer $bytes): Buffer
     {
-        $binaryValue = hex2bin($bytes->toString());
-        $hash256 = hash('sha256', $binaryValue, true);
+        $hash256 = hash('sha256', $bytes->toUtf8(), true);
         $hash160 = hash('ripemd160', $hash256, true);
-        $hexValue = bin2hex($hash160);
 
-        return Buffer::from($hexValue)->slice(0, 32);
+        return Buffer::from($hash160);
     }
 
     public static function sha512Half(Buffer|string $input): Buffer
     {
-        if(!is_string($input)) {
-            $input = $input->toString();
+        if ($input instanceof Buffer) {
+            $input = $input->toUtf8();
+        } else if (preg_match('/^[0-9a-fA-F]+$/', $input)) {
+            $input = hex2bin($input);
         }
 
-        $binaryValue = hex2bin($input);
-        $binaryHash = hash('sha512', $binaryValue, true);
-        $hexValue = bin2hex($binaryHash);
+        $binaryHash = hash('sha512', $input, true);
 
-        return Buffer::from($hexValue)->slice(0, 32);
+        return Buffer::from(substr($binaryHash, 0, 32));
     }
 
     /**

--- a/src/Core/RippleAddressCodec/AddressCodec.php
+++ b/src/Core/RippleAddressCodec/AddressCodec.php
@@ -58,7 +58,7 @@ class AddressCodec extends CodecWithXrpAlphabet
 
         $hex = array_map(fn($item) => sprintf('%02X', $item), $bytes);
 
-        return $this->encodeChecked(Buffer::from(join('', $hex)));
+        return $this->encodeChecked(Buffer::from(join('', $hex), 'hex'));
     }
 
     public function xAddressToClassicAddress(string $xAddress): array

--- a/src/Core/RippleAddressCodec/BaseX.php
+++ b/src/Core/RippleAddressCodec/BaseX.php
@@ -162,18 +162,14 @@ class BaseX
             $it4++;
         }
 
-        $vch = Buffer::from(str_repeat('00', $zeroes + ($size - $it4)));
-        $vch = $vch->toArray();
+        $vch = array_fill(0, $zeroes + ($size - $it4), 0);
         $j = $zeroes;
 
         while ($it4 !== $size) {
             $vch[$j++] = $b256[$it4++];
         }
 
-        $hexStr = join('', array_map(fn($item) => sprintf('%02X', $item), $vch));
-
-        //decimalArrayToHexStr
-        return Buffer::from($hexStr);
+        return Buffer::from($vch);
     }
 
     /**

--- a/src/Core/RippleAddressCodec/Codec.php
+++ b/src/Core/RippleAddressCodec/Codec.php
@@ -33,17 +33,16 @@ class Codec
 
         $defaultOptions = [
             'versionTypes' => ['ed25519', 'secp256k1'],
-            'version' => [[1, 225, 75], 33],
+            'versions' => [[1, 225, 75], [33]],
             'expectedLength' => 16
         ];
 
         $options = array_replace($defaultOptions, $options);
 
         $versions = $options['versions'];
-        $types = $options['versionTypes'];
+        $types = $options['versionTypes'] ?? null;
 
-
-        if (count($options['versions']) > 1 && !$options['expectedLength']) {
+        if (count($versions) > 1 && !$options['expectedLength']) {
             throw new Exception('expectedLength is required because there are >= 2 possible versions');
         }
 
@@ -63,12 +62,14 @@ class Codec
                 ];
             }
         }
+
+        throw new Exception('Unknown version');
     }
 
     public function encodeChecked(Buffer $bytes): string
     {
         $check = $this->sha256($this->sha256($bytes))->slice(0,4);
-        return $this->encodeRaw(Buffer::concat([$bytes->toArray(), $check->toArray()]));
+        return $this->encodeRaw(Buffer::concat([$bytes, $check]));
     }
 
     public function decodeChecked(string $base58string): Buffer
@@ -92,7 +93,8 @@ class Codec
             throw new Exception('unexpected_payload_length: bytes.length does not match expectedLength. Ensure that the bytes are a Buffer.');
         }
 
-        $bytes->prependBuffer(Buffer::from($versions));
+        $versionBytes = is_numeric($versions[0]) ? $versions : $versions[0];
+        $bytes = Buffer::concat([Buffer::from($versionBytes), $bytes]);
 
         return $this->encodeChecked($bytes);
     }
@@ -109,16 +111,14 @@ class Codec
 
     private function sha256(Buffer $bytes): Buffer
     {
-        $binaryValue = hex2bin($bytes->toString());
-        $binaryHash = hash('sha256', $binaryValue, true);
-        $hexValue = bin2hex($binaryHash);
-        return Buffer::from($hexValue);
+        $binaryHash = hash('sha256', $bytes->toUtf8(), true);
+        return Buffer::from($binaryHash);
     }
 
     private function verifyCheckSum(Buffer $bytes): bool
     {
         $computed = $this->sha256($this->sha256($bytes->slice(0,-4)))->slice(0,4);
         $checksum = $bytes->slice(-4);
-        return $computed->toString() === $checksum->toString(); //TODO: Perhaps make Buffer comparable
+        return $computed->toUtf8() === $checksum->toUtf8();
     }
 }

--- a/src/Core/RippleBinaryCodec/Types/AccountId.php
+++ b/src/Core/RippleBinaryCodec/Types/AccountId.php
@@ -41,7 +41,7 @@ class AccountId extends Hash160
         $isHex = (preg_match(self::HEX_REGEX, $serializedJson) === 1);
 
         if ($isHex) {
-            return new AccountId(Buffer::from($serializedJson));
+            return new AccountId(Buffer::from($serializedJson, 'hex'));
         }
 
         $addressCodec = new AddressCodec();

--- a/src/Core/RippleBinaryCodec/Types/Amount.php
+++ b/src/Core/RippleBinaryCodec/Types/Amount.php
@@ -106,7 +106,7 @@ class Amount extends SerializedType
 
             $hex1 = str_pad($bigInteger->shiftedRight(32)->toBase(16), 8, '0', STR_PAD_LEFT);
             $hex2 = str_pad($bigInteger->and(0x00000000ffffffff)->toBase(16), 8, '0', STR_PAD_LEFT);
-            $amount = Buffer::from($hex1 . $hex2);
+            $amount = Buffer::from($hex1 . $hex2, 'hex');
 
             $amount[0] |= 0x80;
 

--- a/src/Core/RippleBinaryCodec/Types/Blob.php
+++ b/src/Core/RippleBinaryCodec/Types/Blob.php
@@ -38,6 +38,6 @@ class Blob extends SerializedType
 
     public static function fromJson(string $serializedJson): SerializedType
     {
-        return new Blob(Buffer::from($serializedJson));
+        return new Blob(Buffer::from($serializedJson, 'hex'));
     }
 }

--- a/src/Core/RippleBinaryCodec/Types/Currency.php
+++ b/src/Core/RippleBinaryCodec/Types/Currency.php
@@ -53,7 +53,7 @@ class Currency extends Hash160
             throw new \Exception('Unsupported Currency representation: ' . $serializedJson);
         }
 
-        $bytes = strlen($serializedJson) === 3 ? static::isoToBytes($serializedJson) : Buffer::from($serializedJson);
+        $bytes = strlen($serializedJson) === 3 ? static::isoToBytes($serializedJson) : Buffer::from($serializedJson, 'hex');
 
         return new Currency($bytes);
     }

--- a/src/Core/RippleBinaryCodec/Types/Hash128.php
+++ b/src/Core/RippleBinaryCodec/Types/Hash128.php
@@ -35,6 +35,6 @@ class Hash128 extends Hash
 
     public static function fromJson(string $serializedJson): SerializedType
     {
-        return new Hash128(Buffer::from($serializedJson));
+        return new Hash128(Buffer::from($serializedJson, 'hex'));
     }
 }

--- a/src/Core/RippleBinaryCodec/Types/Hash160.php
+++ b/src/Core/RippleBinaryCodec/Types/Hash160.php
@@ -35,6 +35,6 @@ class Hash160 extends Hash
 
     public static function fromJson(string $serializedJson): SerializedType
     {
-        return new Hash160(Buffer::from($serializedJson));
+        return new Hash160(Buffer::from($serializedJson, 'hex'));
     }
 }

--- a/src/Core/RippleBinaryCodec/Types/Hash256.php
+++ b/src/Core/RippleBinaryCodec/Types/Hash256.php
@@ -35,6 +35,6 @@ class Hash256 extends Hash
 
     public static function fromJson(string $serializedJson): SerializedType
     {
-        return new Hash256(Buffer::from($serializedJson));
+        return new Hash256(Buffer::from($serializedJson, 'hex'));
     }
 }

--- a/src/Core/RippleBinaryCodec/Types/UnsignedInt16.php
+++ b/src/Core/RippleBinaryCodec/Types/UnsignedInt16.php
@@ -28,7 +28,7 @@ class UnsignedInt16 extends UnsignedInt
             $serializedJson = (int) json_decode($serializedJson);
         }
 
-        return new UnsignedInt16(Buffer::from(dechex($serializedJson)));
+        return new UnsignedInt16(Buffer::from(str_pad(dechex($serializedJson), 4, '0', STR_PAD_LEFT), 'hex'));
     }
 
     public function toBytes(): Buffer

--- a/src/Core/RippleBinaryCodec/Types/UnsignedInt192.php
+++ b/src/Core/RippleBinaryCodec/Types/UnsignedInt192.php
@@ -24,10 +24,10 @@ class UnsignedInt192 extends UnsignedInt
     public static function fromJson(string|int $serializedJson): SerializedType
     {
         if (is_int($serializedJson)) {
-             $serializedJson = (string)$serializedJson;
+            $serializedJson = (string)$serializedJson;
         }
 
-        return new UnsignedInt192(Buffer::from($serializedJson));
+        return new UnsignedInt192(Buffer::from($serializedJson, 'hex'));
     }
 
     public function toBytes(): Buffer

--- a/src/Core/RippleBinaryCodec/Types/UnsignedInt32.php
+++ b/src/Core/RippleBinaryCodec/Types/UnsignedInt32.php
@@ -28,7 +28,7 @@ class UnsignedInt32 extends UnsignedInt
             $serializedJson = (int) json_decode($serializedJson);
         }
 
-        return new UnsignedInt32(Buffer::from(dechex($serializedJson)));
+        return new UnsignedInt32(Buffer::from(str_pad(dechex($serializedJson), 8, '0', STR_PAD_LEFT), 'hex'));
     }
 
     public function toBytes(): Buffer

--- a/src/Core/RippleBinaryCodec/Types/UnsignedInt384.php
+++ b/src/Core/RippleBinaryCodec/Types/UnsignedInt384.php
@@ -24,10 +24,10 @@ class UnsignedInt384 extends UnsignedInt
     public static function fromJson(string|int $serializedJson): SerializedType
     {
         if (is_int($serializedJson)) {
-             $serializedJson = (string)$serializedJson;
+            $serializedJson = (string)$serializedJson;
         }
 
-        return new UnsignedInt384(Buffer::from($serializedJson));
+        return new UnsignedInt384(Buffer::from($serializedJson, 'hex'));
     }
 
     public function toBytes(): Buffer

--- a/src/Core/RippleBinaryCodec/Types/UnsignedInt512.php
+++ b/src/Core/RippleBinaryCodec/Types/UnsignedInt512.php
@@ -24,10 +24,10 @@ class UnsignedInt512 extends UnsignedInt
     public static function fromJson(string|int $serializedJson): SerializedType
     {
         if (is_int($serializedJson)) {
-             $serializedJson = (string)$serializedJson;
+            $serializedJson = (string)$serializedJson;
         }
 
-        return new UnsignedInt512(Buffer::from($serializedJson));
+        return new UnsignedInt512(Buffer::from($serializedJson, 'hex'));
     }
 
     public function toBytes(): Buffer

--- a/src/Core/RippleBinaryCodec/Types/UnsignedInt64.php
+++ b/src/Core/RippleBinaryCodec/Types/UnsignedInt64.php
@@ -25,7 +25,7 @@ class UnsignedInt64 extends UnsignedInt
     public static function fromJson(string $serializedJson): UnsignedInt64
     {
         $bigInteger = BigInteger::fromBase($serializedJson, 10);
-        return new UnsignedInt64(Buffer::from($bigInteger->toBase(16)));
+        return new UnsignedInt64(Buffer::from(str_pad($bigInteger->toBase(16), 16, '0', STR_PAD_LEFT), 'hex'));
     }
 
     public function toBytes(): Buffer

--- a/src/Core/RippleBinaryCodec/Types/UnsignedInt8.php
+++ b/src/Core/RippleBinaryCodec/Types/UnsignedInt8.php
@@ -30,7 +30,7 @@ class UnsignedInt8 extends UnsignedInt
             $serializedJson = (int) json_decode($serializedJson);
         }
 
-        return new UnsignedInt8(Buffer::from(dechex($serializedJson)));
+        return new UnsignedInt8(Buffer::from(str_pad(dechex($serializedJson), 2, '0', STR_PAD_LEFT), 'hex'));
     }
 
     public function valueOf(): int|string

--- a/src/Core/RippleBinaryCodec/Types/UnsignedInt96.php
+++ b/src/Core/RippleBinaryCodec/Types/UnsignedInt96.php
@@ -27,7 +27,7 @@ class UnsignedInt96 extends UnsignedInt
              $serializedJson = (string)$serializedJson;
         }
 
-        return new UnsignedInt96(Buffer::from($serializedJson));
+        return new UnsignedInt96(Buffer::from($serializedJson, 'hex'));
     }
 
     public function toBytes(): Buffer

--- a/src/Core/RippleKeyPairs/Ed25519KeyPairService.php
+++ b/src/Core/RippleKeyPairs/Ed25519KeyPairService.php
@@ -46,7 +46,7 @@ class Ed25519KeyPairService extends AbstractKeyPairService implements KeyPairSer
         }
 
         $rawPrivateKey = MathUtilities::sha512Half($seed);
-        $rawKeyPair = $this->elliptic->keyFromSecret($rawPrivateKey->toString());
+        $rawKeyPair = $this->elliptic->keyFromSecret(bin2hex($rawPrivateKey->toUtf8()));
 
         $publicKey = self::PREFIX_ED25519 . Buffer::from($rawKeyPair->getPublic())->toString();
         $privateKey = self::PREFIX_ED25519 . Buffer::from($rawKeyPair->getSecret())->toString();
@@ -56,8 +56,8 @@ class Ed25519KeyPairService extends AbstractKeyPairService implements KeyPairSer
 
     public function sign(Buffer|string $message, string $privateKey): string
     {
-        if (!is_string($message)) {
-            $message = $message->toString();
+        if ($message instanceof Buffer) {
+            $message = bin2hex($message->toUtf8());
         }
 
         $signed = $this->elliptic->sign($message, substr($privateKey, 2));
@@ -67,8 +67,8 @@ class Ed25519KeyPairService extends AbstractKeyPairService implements KeyPairSer
 
     public function verify(Buffer|string $message, string $signature, string $publicKey): bool
     {
-        if (!is_string($message)) {
-            $message = $message->toString();
+        if ($message instanceof Buffer) {
+            $message = bin2hex($message->toUtf8());
         }
 
         return $this->elliptic->verify($message, $signature, substr($publicKey, 2));

--- a/src/Core/RippleKeyPairs/Secp256k1KeyPairService.php
+++ b/src/Core/RippleKeyPairs/Secp256k1KeyPairService.php
@@ -40,9 +40,6 @@ class Secp256k1KeyPairService extends AbstractKeyPairService implements KeyPairS
         return $this->addressCodec->encodeSeed($entropy, 'secp256k1');
     }
 
-    /**
-     * @throws Exception Error
-     */
     public function deriveKeyPair(Buffer|string $seed, bool $validator = false, int $accountIndex = 0): KeyPair
     {
         if (is_string($seed)) {
@@ -61,31 +58,26 @@ class Secp256k1KeyPairService extends AbstractKeyPairService implements KeyPairS
 
     public function sign(Buffer|string $message, string $privateKey): string
     {
-        if (!is_string($message)) {
-            $message = $message->toString();
-        }
+        $messageBytes = ($message instanceof Buffer) ? $message->toUtf8() : $message;
 
-        $hash = MathUtilities::sha512Half($message);
+        $hash = MathUtilities::sha512Half($messageBytes);
         $signed = $this->elliptic->sign(
-            $hash->toString(),
-            //substr($privateKey, 2),
-            $privateKey,//substr($privateKey, 2),
+            bin2hex($hash->toUtf8()),
+            $privateKey,
             'hex',
             ['canonical' => true]
         )->toDER('hex');
 
-        return Buffer::from($signed)->toString();
+        return strtoupper($signed);
     }
 
     public function verify(Buffer|string $message, string $signature, string $publicKey): bool
     {
-        if (!is_string($message)) {
-            $message = $message->toString();
-        }
+        $messageBytes = ($message instanceof Buffer) ? $message->toUtf8() : $message;
 
-        $hash = MathUtilities::sha512Half($message);
+        $hash = MathUtilities::sha512Half($messageBytes);
 
-        return $this->elliptic->verify($hash->toString(), $signature, $publicKey, 'hex');
+        return $this->elliptic->verify(bin2hex($hash->toUtf8()), $signature, $publicKey, 'hex');
     }
 
     /**
@@ -101,20 +93,19 @@ class Secp256k1KeyPairService extends AbstractKeyPairService implements KeyPairS
      */
     private function derivePrivateKey(Buffer $seed, bool $validator = false, int  $accountIndex = 0): string
     {
-        $order = $this->elliptic->n;
         $privateGen = $this->deriveScalar($seed);
 
         //root key
         if ($validator) {
-            return $privateGen->toString('hex');
+            return str_pad($privateGen->toString(16), 64, '0', STR_PAD_LEFT);
         }
 
         $publicGen = $this->elliptic->g->mul($privateGen);
 
-        return $this->deriveScalar(Buffer::from($publicGen->encodeCompressed('hex')), $accountIndex)
+        return $this->deriveScalar(Buffer::from($publicGen->encodeCompressed('hex'), 'hex'), $accountIndex)
             ->add($privateGen)
             ->mod($this->elliptic->n)
-            ->toString('hex');
+            ->toString(16);
     }
 
     private function derivePublicKey(BN $privateKey): string
@@ -124,28 +115,27 @@ class Secp256k1KeyPairService extends AbstractKeyPairService implements KeyPairS
 
     private function deriveScalar(Buffer $seed, ?int $discriminator = null): BN
     {
-        $seedArray = $seed->toArray();
         $zeroBN = new BN(0);
         $seqBN = $zeroBN->_clone();
 
         while (true) {
-            $buffer = Buffer::from($seedArray);
+            $buffer = Buffer::from($seed->toArray());
 
             if (is_int($discriminator)) {
-                $buffer->appendHex('00000000');
+                $buffer->appendHex(str_pad(dechex($discriminator), 8, '0', STR_PAD_LEFT));
             }
 
-            $seqHex = str_pad((string) $seqBN->toString('hex'), 8, '00', STR_PAD_LEFT);
+            $seqHex = str_pad($seqBN->toString(16), 8, '0', STR_PAD_LEFT);
             $buffer->appendHex($seqHex);
 
             $hash = MathUtilities::sha512Half($buffer);
-            $hashBN = new BN($hash->toString(), 16);
+            $hashBN = new BN(bin2hex($hash->toUtf8()), 16);
 
             if($hashBN->cmp($zeroBN) != 0 && $hashBN->cmp($this->elliptic->n) < 0) {
                 return $hashBN;
             }
 
-            $seqBN = $seqBN->add(1);
+            $seqBN = $seqBN->add(new BN(1));
         }
     }
 }

--- a/tests/Core/RippleAddressCodec/AddressCodecTest.php
+++ b/tests/Core/RippleAddressCodec/AddressCodecTest.php
@@ -57,7 +57,7 @@ class AddressCodecTest extends TestCase
     public function testEncodeEd25519Seed(): void
     {
         $encoded = $this->addressCodec->encodeSeed(
-            Buffer::from("4C3A1D213FBDFB14C7C28D609469B341"),
+            Buffer::from("4C3A1D213FBDFB14C7C28D609469B341", 'hex'),
             'ed25519'
         );
 
@@ -84,7 +84,7 @@ class AddressCodecTest extends TestCase
     public function testEncodeSecp256k1Seed(): void
     {
         $encoded = $this->addressCodec->encodeSeed(
-            Buffer::from('CF2DE378FBDD7E2EE87D486DFB5A7BFF'),
+            Buffer::from('CF2DE378FBDD7E2EE87D486DFB5A7BFF', 'hex'),
             'secp256k1'
         );
 


### PR DESCRIPTION
## Summary
- Bumped hardcastle/buffer dependency to 1.0.0 and fixed all resulting compatibility issues.
- Fixed core cryptographic logic in Secp256k1KeyPairService, CoreUtilities, and RippleBinaryCodec types that were broken by the new Buffer::from() behavior.
