### PR TITLE
Merge injectable-definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,16 +90,14 @@ reference binary and decoding back to the reference JSON).
   against Testnet; every transaction returned `tesSUCCESS`.
 
 ### Security
-- `guzzlehttp/guzzle` was locked to 7.10.0, which carries 13 advisories including
-  one of high severity (CVE-2026-69246, noncanonical hosts bypassing host-based
-  checks). The constraint is raised from `^7.4` to `^7.15.2`, the first release in
-  which all of them are fixed, and the lock now holds 7.15.5 and psr7 2.13.1.
-  `composer audit` is clean.
+- The `guzzlehttp/guzzle` constraint `^7.4` allowed every release from 7.4.0 up to
+  7.15.1, all of which carry open advisories - among them CVE-2026-69246 (high,
+  noncanonical hosts bypassing host-based checks), fixed in 7.15.2. Consumers
+  resolving the dependency tree could therefore end up on a vulnerable version.
+  The constraint is raised to `^7.15.2`, the first release fixing all of them.
+  `composer audit` is clean against the resulting tree.
 
 ### Changed
-- The lock file was out of date since the buffer bump: it pinned
-  `hardcastle/buffer` 1.0.0 while composer.json required `^1.0.1`, so a fresh
-  `composer install` failed. Regenerated; buffer is now 1.0.1 and brick/math 0.14.8.
 - `composer.json` declares `"php": "^8.2"`. It only had `config.platform`, which is
   a development setting and does not constrain installs. 8.2 is what CI tests.
 - `brick/math` is narrowed from `>=0.11 <0.18` to `>=0.11 <0.15`. The library uses

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)..
 
+## [2.1.0] - unreleased
+
+### Added
+- The binary codec works against definitions handed in from outside, so a package
+  for another network can supply its own `definitions.json`. `Definitions::fromArray()`
+  and `Definitions::fromFile()` build such a set, and `BinaryCodec`, `BinaryParser`,
+  `Wallet` and `JsonRpcClient` all take an optional `Definitions` instance. Omitting
+  it keeps the bundled XRP Ledger definitions, so existing code is unaffected.
+  The definitions travel through the whole encode and decode, including nested
+  objects and arrays, and never touch the shared default instance - one process can
+  talk to both networks at once.
+- `HashLedger::hashSignedTx()`, `Sugar\getLastLedgerSequence()` and
+  `Sugar\isAccountDelete()` take an optional `Definitions` instance as well, and
+  the call sites pass the ones of the client or wallet in hand.
+- README section "Using your own definitions".
+
+### Fixed
+- `Wallet::sign()` encoded against the wallet's definitions but hashed the result
+  through the default ones. Hashing decodes the blob to verify a signature is
+  present, and decoding resolves every field, so signing a transaction carrying a
+  field only the injected definitions know threw inside `sign()`.
+- `HashLedger::hashSignedTx()` produces the hashed blob itself when handed an
+  array. With the wrong definitions that yields a different blob and therefore a
+  wrong hash, with nothing to indicate it.
+
 ## [2.0.0] - 2026-08-24
 
 Brings the library to parity with rippled 3.3.0 / ripple-binary-codec 5.0.0. The

--- a/README.md
+++ b/README.md
@@ -50,8 +50,40 @@ library resolves the overlap in favour of the XRP Ledger.
 - `hooksDefinitions.json` predates the current Xahau release and is missing
   `Remit`, `SetRemarks`, `Cron` and `CronSet`.
 
-A network aware `Definitions` instance that resolves this properly is planned
-for the next release.
+### Using your own definitions
+
+Since 2.1.0 the codec works against definitions handed in from outside, so a
+package for another network can supply its own `definitions.json` instead of the
+bundled one. Every entry point takes an optional `Definitions` instance and
+falls back to the XRP Ledger when it is omitted:
+
+```php
+use Hardcastle\XRPL_PHP\Core\RippleBinaryCodec\BinaryCodec;
+use Hardcastle\XRPL_PHP\Core\RippleBinaryCodec\Definitions\Definitions;
+use Hardcastle\XRPL_PHP\Client\JsonRpcClient;
+use Hardcastle\XRPL_PHP\Wallet\Wallet;
+
+$definitions = Definitions::fromFile('/path/to/xahau-definitions.json');
+// or Definitions::fromArray($decodedJson);
+
+$codec  = new BinaryCodec($definitions);
+$wallet = Wallet::fromSeed($seed, $definitions);
+$client = new JsonRpcClient('https://xahau.network', null, null, 3.0, $definitions);
+```
+
+A node serves its own definitions, so they can be fetched rather than vendored:
+
+```console
+curl -X POST https://xahau.network -H 'Content-Type: application/json' \
+  -d '{"method":"server_definitions","params":[{}]}'
+```
+
+The definitions travel through the whole encode and decode, including nested
+objects and arrays. They do not touch the shared default instance, so a process
+can talk to both networks at once.
+
+A dedicated Xahau package building on this is planned; the Xahau types will then
+move out of this library.
 
 ## Installation
 

--- a/src/Client/JsonRpcClient.php
+++ b/src/Client/JsonRpcClient.php
@@ -25,6 +25,7 @@ use Hardcastle\XRPL_PHP\Models\BaseResponse;
 use Hardcastle\XRPL_PHP\Models\ErrorResponse;
 use Hardcastle\XRPL_PHP\Models\Ledger\LedgerRequest;
 use Hardcastle\XRPL_PHP\Models\Transaction\SubmitResponse;
+use Hardcastle\XRPL_PHP\Core\RippleBinaryCodec\Definitions\Definitions;
 use Hardcastle\XRPL_PHP\Models\Transaction\TransactionTypes\BaseTransaction as Transaction;
 use Hardcastle\XRPL_PHP\Models\Transaction\TxResponse;
 use Hardcastle\XRPL_PHP\Wallet\Wallet;
@@ -60,7 +61,8 @@ class JsonRpcClient
         string $connectionUrl,
         ?float $feeCushion = null,
         ?string $maxFeeXrp = null,
-        private readonly float $timeout = 3.0
+        private readonly float $timeout = 3.0,
+        private ?Definitions $definitions = null
     ) {
         $this->connectionUrl = $this->getNetworkUrl($connectionUrl);
 
@@ -273,6 +275,20 @@ class JsonRpcClient
     /**
      * @return string
      */
+    /**
+     * The definitions transactions of this connection are encoded against.
+     *
+     * Defaults to the bundled XRP Ledger definitions; a client for another
+     * network is constructed with that network's set.
+     *
+     * @return Definitions
+     * @throws Exception
+     */
+    public function getDefinitions(): Definitions
+    {
+        return $this->definitions ??= Definitions::getInstance();
+    }
+
     public function getConnectionUrl(): string
     {
         return $this->connectionUrl;

--- a/src/Core/RippleBinaryCodec/Binary.php
+++ b/src/Core/RippleBinaryCodec/Binary.php
@@ -10,14 +10,40 @@
 
 namespace Hardcastle\XRPL_PHP\Core\RippleBinaryCodec;
 
+use Hardcastle\XRPL_PHP\Core\RippleBinaryCodec\Definitions\Definitions;
 use Hardcastle\XRPL_PHP\Core\RippleBinaryCodec\Serdes\BinaryParser;
 use Hardcastle\XRPL_PHP\Core\RippleBinaryCodec\Types\StObject;
 
 class Binary
 {
+    protected ?Definitions $definitions = null;
+
+    /**
+     * The definitions this codec works against.
+     *
+     * Defaults to the bundled XRP Ledger definitions. A package for another
+     * network passes its own set into the constructor.
+     *
+     * @param Definitions|null $definitions
+     * @throws \Exception
+     */
+    public function __construct(?Definitions $definitions = null)
+    {
+        $this->definitions = $definitions;
+    }
+
+    /**
+     * @return Definitions
+     * @throws \Exception
+     */
+    public function getDefinitions(): Definitions
+    {
+        return $this->definitions ??= Definitions::getInstance();
+    }
+
     public function makeParser(string $bytes): BinaryParser
     {
-        return new BinaryParser($bytes);
+        return new BinaryParser($bytes, $this->getDefinitions());
     }
 
     /*

--- a/src/Core/RippleBinaryCodec/BinaryCodec.php
+++ b/src/Core/RippleBinaryCodec/BinaryCodec.php
@@ -32,7 +32,7 @@ class BinaryCodec extends Binary
             $jsonObject = json_encode($jsonObject);
         }
 
-        return StObject::fromJson($jsonObject)->toString();
+        return StObject::fromJson($jsonObject, $this->getDefinitions())->toString();
     }
 
     /**
@@ -148,6 +148,6 @@ class BinaryCodec extends Binary
      */
     private function isSigningField(string $fieldName): bool
     {
-        return Definitions::getInstance()->getFieldInstance($fieldName)->isSigningField();
+        return $this->getDefinitions()->getFieldInstance($fieldName)->isSigningField();
     }
 }

--- a/src/Core/RippleBinaryCodec/Definitions/Definitions.php
+++ b/src/Core/RippleBinaryCodec/Definitions/Definitions.php
@@ -55,41 +55,20 @@ class Definitions
     /**
      * Definitions constructor.
      *
+     * Without arguments this loads the bundled XRP Ledger definitions and adds
+     * the Xahau ones on top. Pass a definitions array to build an instance for
+     * a different network - see fromArray() and fromFile().
+     *
+     * @param array|null $definitions A decoded definitions.json
      * @throws Exception
      */
-    public function __construct()
+    public function __construct(?array $definitions = null)
     {
-        $path = getenv('XRPL_PHP_DEFINITIONS_FILE_PATH') ?: __DIR__ . "/definitions.json";
-        if (file_exists($path)) {
-            $fileContents = file_get_contents($path);
-        } else {
-            throw new Exception("Definitions file not found.");
-        }
+        $this->definitions = $definitions ?? self::loadDefaultDefinitions();
 
-        $this->definitions = json_decode($fileContents, true);
-
-        $hooksPath = __DIR__ . "/../../../Hooks/hooksDefinitions.json";
-        if (file_exists($hooksPath)) {
-            $hooksDefinitions = json_decode(file_get_contents($hooksPath), true);
-
-            // Xahau reuses ordinals that the XRP Ledger assigns to different
-            // transaction types and fields (e.g. URITokenMint and
-            // XChainAddClaimAttestation are both 45, Xahau's Blob and the
-            // XRPL's DIDDocument are both Blob:26). The Xahau definitions are
-            // therefore only added where the XRPL has nothing of that name -
-            // they never overwrite a mainline entry. Encoding Xahau
-            // transactions keeps working; decoding an ambiguous ordinal
-            // resolves to the XRPL name.
-            $this->definitions['TYPES'] += $hooksDefinitions['TYPES'];
-            $this->definitions['LEDGER_ENTRY_TYPES'] += $hooksDefinitions['LEDGER_ENTRY_TYPES'];
-            $this->definitions['TRANSACTION_RESULTS'] += $hooksDefinitions['TRANSACTION_RESULTS'] ?? [];
-            $this->definitions['TRANSACTION_TYPES'] += $hooksDefinitions['TRANSACTION_TYPES'] ?? [];
-
-            $knownFields = array_column($this->definitions['FIELDS'], 0);
-            foreach ($hooksDefinitions['FIELDS'] as $field) {
-                if (!in_array($field[0], $knownFields, true)) {
-                    $this->definitions['FIELDS'][] = $field;
-                }
+        foreach (['TYPES', 'LEDGER_ENTRY_TYPES', 'TRANSACTION_RESULTS', 'TRANSACTION_TYPES', 'FIELDS'] as $section) {
+            if (!isset($this->definitions[$section])) {
+                throw new Exception("Definitions are missing the section {$section}.");
             }
         }
 
@@ -130,6 +109,86 @@ class Definitions
             // mainline field that shares its ordinal (see the merge above).
             $this->fieldIdNameMap[$fieldHeader->getTypeCode() . ":" . $fieldHeader->getFieldCode()] ??= $fieldName;
         }
+    }
+
+
+    /**
+     * Build an instance from a decoded definitions.json.
+     *
+     * This is the entry point for other networks: a Xahau package passes its
+     * own definitions here instead of relying on the bundled ones.
+     *
+     * @param array $definitions
+     * @return Definitions
+     * @throws Exception
+     */
+    public static function fromArray(array $definitions): Definitions
+    {
+        return new Definitions($definitions);
+    }
+
+    /**
+     * Build an instance from a definitions.json file.
+     *
+     * @param string $path
+     * @return Definitions
+     * @throws Exception
+     */
+    public static function fromFile(string $path): Definitions
+    {
+        if (!file_exists($path)) {
+            throw new Exception("Definitions file not found: {$path}");
+        }
+
+        $definitions = json_decode(file_get_contents($path), true);
+        if (!is_array($definitions)) {
+            throw new Exception("Definitions file does not contain valid JSON: {$path}");
+        }
+
+        return new Definitions($definitions);
+    }
+
+    /**
+     * The bundled XRP Ledger definitions with the Xahau ones added on top.
+     *
+     * Xahau reuses ordinals that the XRP Ledger assigns to different
+     * transaction types and fields (e.g. URITokenMint and
+     * XChainAddClaimAttestation are both 45, Xahau's Blob and the XRPL's
+     * DIDDocument are both Blob:26). The Xahau definitions are therefore only
+     * added where the XRP Ledger has nothing of that name - they never
+     * overwrite a mainline entry. Encoding Xahau transactions keeps working;
+     * decoding an ambiguous ordinal resolves to the XRP Ledger name.
+     *
+     * @return array
+     * @throws Exception
+     */
+    private static function loadDefaultDefinitions(): array
+    {
+        $path = getenv('XRPL_PHP_DEFINITIONS_FILE_PATH') ?: __DIR__ . "/definitions.json";
+        if (!file_exists($path)) {
+            throw new Exception("Definitions file not found.");
+        }
+
+        $definitions = json_decode(file_get_contents($path), true);
+
+        $hooksPath = __DIR__ . "/../../../Hooks/hooksDefinitions.json";
+        if (file_exists($hooksPath)) {
+            $hooksDefinitions = json_decode(file_get_contents($hooksPath), true);
+
+            $definitions['TYPES'] += $hooksDefinitions['TYPES'];
+            $definitions['LEDGER_ENTRY_TYPES'] += $hooksDefinitions['LEDGER_ENTRY_TYPES'];
+            $definitions['TRANSACTION_RESULTS'] += $hooksDefinitions['TRANSACTION_RESULTS'] ?? [];
+            $definitions['TRANSACTION_TYPES'] += $hooksDefinitions['TRANSACTION_TYPES'] ?? [];
+
+            $knownFields = array_column($definitions['FIELDS'], 0);
+            foreach ($hooksDefinitions['FIELDS'] as $field) {
+                if (!in_array($field[0], $knownFields, true)) {
+                    $definitions['FIELDS'][] = $field;
+                }
+            }
+        }
+
+        return $definitions;
     }
 
     public static function getInstance(): Definitions

--- a/src/Core/RippleBinaryCodec/Serdes/BinaryParser.php
+++ b/src/Core/RippleBinaryCodec/Serdes/BinaryParser.php
@@ -26,15 +26,32 @@ class BinaryParser
 {
     private Buffer $bytes;
 
+    private ?Definitions $definitions;
+
     /**
      *
      *
      * @param string $hexBytes
      * @throws Exception
      */
-    public function __construct(string $hexBytes)
+    public function __construct(string $hexBytes, ?Definitions $definitions = null)
     {
         $this->bytes = Buffer::from($hexBytes, 'hex');
+        $this->definitions = $definitions;
+    }
+
+    /**
+     * The definitions this parser reads field headers against.
+     *
+     * Defaults to the bundled XRP Ledger definitions. Another network passes
+     * its own set in, and it travels with the parser through the whole decode.
+     *
+     * @return Definitions
+     * @throws \Exception
+     */
+    public function getDefinitions(): Definitions
+    {
+        return $this->definitions ??= Definitions::getInstance();
     }
 
     /**
@@ -201,9 +218,9 @@ class BinaryParser
     public function readField(): FieldInstance
     {
         $fieldHeader = $this->readFieldHeader();
-        $fieldName = Definitions::getInstance()->getFieldNameFromHeader($fieldHeader);
+        $fieldName = $this->getDefinitions()->getFieldNameFromHeader($fieldHeader);
 
-        return Definitions::getInstance()->getFieldInstance($fieldName);
+        return $this->getDefinitions()->getFieldInstance($fieldName);
     }
 
     /**

--- a/src/Core/RippleBinaryCodec/Types/StArray.php
+++ b/src/Core/RippleBinaryCodec/Types/StArray.php
@@ -11,6 +11,7 @@
 namespace Hardcastle\XRPL_PHP\Core\RippleBinaryCodec\Types;
 
 use Hardcastle\Buffer\Buffer;
+use Hardcastle\XRPL_PHP\Core\RippleBinaryCodec\Definitions\Definitions;
 use Hardcastle\XRPL_PHP\Core\RippleBinaryCodec\Serdes\BinaryParser;
 use Hardcastle\XRPL_PHP\Core\RippleBinaryCodec\Serdes\BinarySerializer;
 
@@ -21,6 +22,9 @@ class StArray extends SerializedType
     public const ARRAY_END_MARKER_HEX = "F1";
 
     public const ARRAY_END_MARKER_NAME = "ArrayEndMarker";
+
+    /** @see StObject::$definitions */
+    protected ?Definitions $definitions = null;
 
     public static function fromParser(BinaryParser $parser, ?int $lengthHint = null): SerializedType
     {
@@ -41,27 +45,36 @@ class StArray extends SerializedType
 
         $binarySerializer->put(self::ARRAY_END_MARKER_HEX);
 
-        return new StArray($binarySerializer->getBytes());
+        $array = new StArray($binarySerializer->getBytes());
+        $array->definitions = $parser->getDefinitions();
+
+        return $array;
     }
 
-    public static function fromJson(string $serializedJson): SerializedType
+    public static function fromJson(string $serializedJson, ?Definitions $definitions = null): SerializedType
     {
         $json = json_decode($serializedJson);
         $bytes = Buffer::alloc(0);
 
         foreach($json as $item) {
-            $object = StObject::fromJson(json_encode($item));
+            $object = StObject::fromJson(json_encode($item), $definitions);
             $bytes->appendBuffer($object->toBytes());
         }
 
         $bytes->appendHex(self::ARRAY_END_MARKER_HEX);
 
-        return new StArray($bytes);
+        $array = new StArray($bytes);
+        $array->definitions = $definitions;
+
+        return $array;
     }
 
     public function toJson(): array|string
     {
-        $binaryParser = new BinaryParser($this->bytes->toString());
+        $binaryParser = new BinaryParser(
+            $this->bytes->toString(),
+            $this->definitions ?? Definitions::getInstance()
+        );
         $array = [];
 
         while (!$binaryParser->end()) {

--- a/src/Core/RippleBinaryCodec/Types/StObject.php
+++ b/src/Core/RippleBinaryCodec/Types/StObject.php
@@ -34,6 +34,12 @@ class StObject extends SerializedType
 
     public const DESTINATION_TAG = 'DestinationTag';
 
+    /**
+     * Set when the object was parsed, so that toJson() resolves field names
+     * against the same definitions the parser used.
+     */
+    protected ?Definitions $definitions = null;
+
 
     public static function fromParser(BinaryParser $parser, ?int $lengthHint = null): SerializedType
     {
@@ -53,14 +59,17 @@ class StObject extends SerializedType
             }
         }
 
-        return new StObject($binarySerializer->getBytes());
+        $object = new StObject($binarySerializer->getBytes());
+        $object->definitions = $parser->getDefinitions();
+
+        return $object;
     }
 
-    public static function fromJson(string $serializedJson): SerializedType
+    public static function fromJson(string $serializedJson, ?Definitions $definitions = null): SerializedType
     {
         $json = json_decode($serializedJson, true);
         $binarySerializer = new BinarySerializer(Buffer::alloc(0));
-        $definitions = Definitions::getInstance();
+        $definitions ??= Definitions::getInstance();
 
         $isUnlModify = false;
 
@@ -96,6 +105,10 @@ class StObject extends SerializedType
 
             if ($serializedTypeInstance instanceof UnsignedInt64 && UnsignedInt64::isBase10Field($key)) {
                 $fieldValue = UnsignedInt64::fromBase10((string)$value);
+            } else if ($serializedTypeInstance instanceof StObject || $serializedTypeInstance instanceof StArray) {
+                // Only these two resolve field names, so only they need to know
+                // which network's definitions are in play.
+                $fieldValue = $serializedTypeInstance::fromJson($value, $definitions);
             } else {
                 $fieldValue = $serializedTypeInstance::fromJson($value);
             }
@@ -112,7 +125,8 @@ class StObject extends SerializedType
 
     public function toJson(): array|string
     {
-        $binaryParser = new BinaryParser($this->bytes->toString());
+        $definitions = $this->definitions ?? Definitions::getInstance();
+        $binaryParser = new BinaryParser($this->bytes->toString(), $definitions);
         $accumulator = [];
 
         while (!$binaryParser->end()) {
@@ -132,7 +146,7 @@ class StObject extends SerializedType
             if(is_array($node)) {
                 $accumulator[$fieldInstance->getName()] = $node;
             } else {
-                $mappedNode = Definitions::getInstance()->mapValueToSpecificField($fieldInstance->getName(), $node);
+                $mappedNode = $definitions->mapValueToSpecificField($fieldInstance->getName(), $node);
                 $accumulator[$fieldInstance->getName()] = (!empty($mappedNode)) ? $mappedNode : $node;
             }
         }

--- a/src/Sugar/autofill.php
+++ b/src/Sugar/autofill.php
@@ -270,7 +270,7 @@ if (! function_exists('Hardcastle\XRPL_PHP\Sugar\autofill')) {
     ): array
     {
         if (is_string($transaction)) {
-            $binaryCodec = new BinaryCodec();
+            $binaryCodec = new BinaryCodec($client->getDefinitions());
             $tx = $binaryCodec->decode($transaction);
         } else if ($transaction instanceof Transaction) {
             $tx = $transaction->toArray();

--- a/src/Sugar/submit.php
+++ b/src/Sugar/submit.php
@@ -6,6 +6,7 @@ use Exception;
 use GuzzleHttp\Promise\PromiseInterface;
 use Hardcastle\XRPL_PHP\Client\JsonRpcClient;
 use Hardcastle\XRPL_PHP\Core\RippleBinaryCodec\BinaryCodec;
+use Hardcastle\XRPL_PHP\Core\RippleBinaryCodec\Definitions\Definitions;
 use Hardcastle\XRPL_PHP\Models\ErrorResponse;
 use Hardcastle\XRPL_PHP\Models\Transaction\SubmitRequest;
 use Hardcastle\XRPL_PHP\Models\Transaction\SubmitResponse;
@@ -27,12 +28,12 @@ function submitRequest(
         throw new Exception('Transaction must be signed');
     }
 
-    $binaryCodec = new BinaryCodec();
+    $binaryCodec = new BinaryCodec($client->getDefinitions());
     $signedTxEncoded = $binaryCodec->encode($signedTransaction);
 
     $submitRequest = new SubmitRequest(
         txBlob: $signedTxEncoded,
-        failHard: isAccountDelete($signedTransaction) || $failHard
+        failHard: isAccountDelete($signedTransaction, $client->getDefinitions()) || $failHard
     );
 
     return $client->request($submitRequest);
@@ -128,7 +129,7 @@ function getSignedTx(
 ): array
 {
     if (is_string($transaction)) {
-        $binaryCodec = new BinaryCodec();
+        $binaryCodec = new BinaryCodec($client->getDefinitions());
         $tx = $binaryCodec->decode($transaction);
     } else if ($transaction instanceof Transaction) {
         $tx = $transaction->toArray();
@@ -157,10 +158,13 @@ function getSignedTx(
  * @param array|string $tx
  * @return int|null
  */
-function getLastLedgerSequence(array|string $tx): int|null
+function getLastLedgerSequence(array|string $tx, ?Definitions $definitions = null): int|null
 {
     if (is_string($tx)) {
-        $binaryCodec = new BinaryCodec();
+        // Decoding resolves every field in the blob, so a transaction from
+        // another network needs that network's definitions even though
+        // LastLedgerSequence itself carries the same ordinal everywhere.
+        $binaryCodec = new BinaryCodec($definitions);
         $tx = $binaryCodec->decode($tx);
     }
 
@@ -173,10 +177,10 @@ function getLastLedgerSequence(array|string $tx): int|null
  * @param array|string $tx
  * @return bool
  */
-function isAccountDelete(array|string $tx): bool
+function isAccountDelete(array|string $tx, ?Definitions $definitions = null): bool
 {
     if (is_string($tx)) {
-        $binaryCodec = new BinaryCodec();
+        $binaryCodec = new BinaryCodec($definitions);
         $tx = $binaryCodec->decode($tx);
     }
 
@@ -229,14 +233,14 @@ if (! function_exists('Hardcastle\XRPL_PHP\Sugar\submitAndWait')) {
     {
         $signedTx = getSignedTx($client, $transaction, $autofill, $wallet);
 
-        $lastLedger = getLastLedgerSequence($signedTx);
+        $lastLedger = getLastLedgerSequence($signedTx, $client->getDefinitions());
         if(is_null($lastLedger)) {
             throw new Exception('Transaction must contain a LastLedgerSequence value for reliable submission.');
         }
 
         $response = submitRequest($client, $signedTx, $failHard)->wait();
 
-        $txHash = HashLedger::hashSignedTx($signedTx);
+        $txHash = HashLedger::hashSignedTx($signedTx, $client->getDefinitions());
 
         return waitForFinalTransactionOutcome(
             $client,

--- a/src/Utils/Hashes/HashLedger.php
+++ b/src/Utils/Hashes/HashLedger.php
@@ -6,6 +6,7 @@ use Exception;
 use Hardcastle\XRPL_PHP\Core\HashPrefix;
 use Hardcastle\XRPL_PHP\Core\MathUtilities;
 use Hardcastle\XRPL_PHP\Core\RippleBinaryCodec\BinaryCodec;
+use Hardcastle\XRPL_PHP\Core\RippleBinaryCodec\Definitions\Definitions;
 use Hardcastle\XRPL_PHP\Models\Transaction\TransactionTypes\BaseTransaction as Transaction;
 
 /**
@@ -27,19 +28,28 @@ class HashLedger
     }
 
     /**
+     * Hash of a signed transaction.
+     *
+     * When given an array the blob that gets hashed is produced here, so the
+     * definitions decide the result - pass the ones the transaction was built
+     * with, otherwise the hash is silently wrong for another network.
+     *
      * @param array|string $tx
+     * @param Definitions|null $definitions
      * @return string
      * @throws Exception
      */
-    public static function hashSignedTx(array|string $tx): string
+    public static function hashSignedTx(array|string $tx, ?Definitions $definitions = null): string
     {
-        $_this = self::getInstance();
+        $binaryCodec = ($definitions === null)
+            ? self::getInstance()->binaryCodec
+            : new BinaryCodec($definitions);
 
         if (is_string($tx)) {
             $txBlob = $tx;
-            $txObject = $_this->binaryCodec->decode($tx);
+            $txObject = $binaryCodec->decode($tx);
         } else {
-            $txBlob = $_this->binaryCodec->encode($tx);
+            $txBlob = $binaryCodec->encode($tx);
             $txObject = $tx;
         }
 

--- a/src/Wallet/Wallet.php
+++ b/src/Wallet/Wallet.php
@@ -4,6 +4,7 @@ namespace Hardcastle\XRPL_PHP\Wallet;
 
 use Exception;
 use Hardcastle\XRPL_PHP\Core\RippleBinaryCodec\BinaryCodec;
+use Hardcastle\XRPL_PHP\Core\RippleBinaryCodec\Definitions\Definitions;
 use Hardcastle\XRPL_PHP\Core\RippleKeyPairs\Ed25519KeyPairService;
 use Hardcastle\XRPL_PHP\Core\RippleKeyPairs\KeyPair;
 use Hardcastle\XRPL_PHP\Core\RippleKeyPairs\KeyPairServiceInterface;
@@ -33,9 +34,12 @@ class Wallet
         private readonly string $privateKey,
         private readonly ?string $seed,
         ?string $masterAddress = null,
+        ?Definitions $definitions = null,
     )
     {
-        $this->binaryCodec = new BinaryCodec();
+        // Signing runs through the binary codec, so a wallet for another
+        // network has to be built with that network's definitions.
+        $this->binaryCodec = new BinaryCodec($definitions);
 
         if (str_starts_with($publicKey, 'ED')) {
             $this->keyPairService = Ed25519KeyPairService::getInstance();
@@ -54,17 +58,20 @@ class Wallet
         }
     }
 
-    public static function generate(string $type = self::DEFAULT_ALGORITHM): Wallet
+    public static function generate(
+        string $type = self::DEFAULT_ALGORITHM,
+        ?Definitions $definitions = null
+    ): Wallet
     {
         $keyPairService = KeyPair::getKeyPairServiceByType($type);
         $seed = $keyPairService->generateSeed();
 
-        return Wallet::fromSeed($seed);
+        return Wallet::fromSeed($seed, $definitions);
     }
 
-    public static function fromSeed(string $seed): Wallet
+    public static function fromSeed(string $seed, ?Definitions $definitions = null): Wallet
     {
-        return self::deriveWallet($seed);
+        return self::deriveWallet($seed, $definitions);
     }
 
     /**
@@ -74,7 +81,7 @@ class Wallet
      * @return Wallet
      * @throws Exception
      */
-    private static function deriveWallet(string $seed): Wallet
+    private static function deriveWallet(string $seed, ?Definitions $definitions = null): Wallet
     {
         $decoded = CoreUtilities::decodeSeed($seed);
         $keyPairService = KeyPair::getKeyPairServiceByType($decoded['type']);
@@ -83,7 +90,9 @@ class Wallet
         return new Wallet(
             $keyPair->getPublicKey(),
             $keyPair->getPrivateKey(),
-            $seed
+            $seed,
+            null,
+            $definitions
         );
     }
 
@@ -140,7 +149,7 @@ class Wallet
 
         $this->checkTxSerialisation($serializedTx, $tx);
 
-        $hash = HashLedger::hashSignedTx($serializedTx);
+        $hash = HashLedger::hashSignedTx($serializedTx, $this->binaryCodec->getDefinitions());
 
         return [
             "tx_blob" => $serializedTx,

--- a/tests/Core/RippleBinaryCodec/Definitions/InjectableDefinitionsTest.php
+++ b/tests/Core/RippleBinaryCodec/Definitions/InjectableDefinitionsTest.php
@@ -1,0 +1,249 @@
+<?php declare(strict_types=1);
+
+namespace Hardcastle\XRPL_PHP\Test\Core\RippleBinaryCodec\Definitions;
+
+use Exception;
+use PHPUnit\Framework\TestCase;
+use Hardcastle\XRPL_PHP\Core\RippleBinaryCodec\BinaryCodec;
+use Hardcastle\XRPL_PHP\Core\RippleBinaryCodec\Definitions\Definitions;
+use Hardcastle\XRPL_PHP\Utils\Hashes\HashLedger;
+use Hardcastle\XRPL_PHP\Wallet\Wallet;
+
+use function Hardcastle\XRPL_PHP\Sugar\getLastLedgerSequence;
+use function Hardcastle\XRPL_PHP\Sugar\isAccountDelete;
+
+/**
+ * The codec has to work against definitions handed in from outside, so that a
+ * package for another network (Xahau being the concrete case) can supply its
+ * own definitions.json instead of the bundled one.
+ *
+ * The tests build an alternative set by remapping ordinals in the bundled
+ * definitions. That is exactly what makes the two networks incompatible in
+ * reality - Xahau assigns MPTokenIssuanceCreate the ordinal 63 where the XRP
+ * Ledger assigns 54 - without pulling a second large fixture into the repo.
+ */
+final class InjectableDefinitionsTest extends TestCase
+{
+    private const ACCOUNT = 'rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe';
+
+    private const SEED = 'sEd7rnfWxwJmRditu2UpSsrZDRgtctn';
+
+    private const DEFINITIONS_PATH = __DIR__
+        . '/../../../../src/Core/RippleBinaryCodec/Definitions/definitions.json';
+
+    /**
+     * The bundled definitions with Payment moved from ordinal 0 to 99.
+     */
+    private static function alternativeDefinitions(): Definitions
+    {
+        $raw = json_decode(file_get_contents(self::DEFINITIONS_PATH), true);
+        $raw['TRANSACTION_TYPES']['Payment'] = 99;
+
+        return Definitions::fromArray($raw);
+    }
+
+    private static function payment(): array
+    {
+        return [
+            'TransactionType' => 'Payment',
+            'Account' => self::ACCOUNT,
+            'Destination' => 'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh',
+            'Amount' => '1000',
+            'Fee' => '10',
+            'Sequence' => 1,
+        ];
+    }
+
+    private static function ordinalOf(string $hex): int
+    {
+        // A transaction starts with the TransactionType field: 12 followed by
+        // the UInt16 ordinal.
+        return hexdec(substr($hex, 2, 4));
+    }
+
+    public function testInjectedDefinitionsAreUsedForEncoding(): void
+    {
+        $default = (new BinaryCodec())->encode(json_encode(self::payment()));
+        $custom = (new BinaryCodec(self::alternativeDefinitions()))->encode(json_encode(self::payment()));
+
+        $this->assertEquals(0, self::ordinalOf($default));
+        $this->assertEquals(99, self::ordinalOf($custom));
+    }
+
+    public function testInjectedDefinitionsAreUsedForDecoding(): void
+    {
+        $definitions = self::alternativeDefinitions();
+        $hex = (new BinaryCodec($definitions))->encode(json_encode(self::payment()));
+
+        $this->assertEquals(
+            'Payment',
+            (new BinaryCodec($definitions))->decode($hex)['TransactionType']
+        );
+    }
+
+    /**
+     * The definitions have to survive the whole decode, including the nested
+     * objects an STArray produces.
+     */
+    public function testDefinitionsTravelIntoNestedObjects(): void
+    {
+        $definitions = self::alternativeDefinitions();
+        $codec = new BinaryCodec($definitions);
+
+        $tx = self::payment();
+        $tx['Memos'] = [['Memo' => ['MemoData' => '48656C6C6F']]];
+
+        $decoded = $codec->decode($codec->encode(json_encode($tx)));
+
+        $this->assertEquals('48656C6C6F', $decoded['Memos'][0]['Memo']['MemoData']);
+        $this->assertEquals('Payment', $decoded['TransactionType']);
+    }
+
+    /**
+     * Signing goes through the codec, so a wallet built with other definitions
+     * has to produce a blob encoded against them.
+     */
+    public function testWalletUsesInjectedDefinitions(): void
+    {
+        $default = Wallet::fromSeed(self::SEED);
+        $custom = Wallet::fromSeed(self::SEED, self::alternativeDefinitions());
+
+        $tx = self::payment();
+        $tx['Account'] = $default->getAddress();
+
+        $this->assertEquals(0, self::ordinalOf($default->sign($tx)['tx_blob']));
+        $this->assertEquals(99, self::ordinalOf($custom->sign($tx)['tx_blob']));
+
+        $this->assertTrue($custom->verifyTransaction($custom->sign($tx)['tx_blob']));
+    }
+
+    /**
+     * An injected set must not leak into the shared default instance.
+     */
+    public function testDefaultInstanceIsNotAffected(): void
+    {
+        self::alternativeDefinitions();
+
+        $this->assertEquals(
+            0,
+            Definitions::getInstance()->mapSpecificFieldFromValue('TransactionType', 'Payment')
+        );
+        $this->assertEquals(
+            0,
+            self::ordinalOf((new BinaryCodec())->encode(json_encode(self::payment())))
+        );
+    }
+
+    public function testFromFile(): void
+    {
+        $definitions = Definitions::fromFile(self::DEFINITIONS_PATH);
+
+        $this->assertEquals(
+            0,
+            $definitions->mapSpecificFieldFromValue('TransactionType', 'Payment')
+        );
+    }
+
+    public function testFromFileRejectsMissingFile(): void
+    {
+        $this->expectExceptionMessage('Definitions file not found');
+
+        Definitions::fromFile(__DIR__ . '/does-not-exist.json');
+    }
+
+    public function testRejectsIncompleteDefinitions(): void
+    {
+        $this->expectExceptionMessage('Definitions are missing the section FIELDS');
+
+        Definitions::fromArray([
+            'TYPES' => [],
+            'LEDGER_ENTRY_TYPES' => [],
+            'TRANSACTION_RESULTS' => [],
+            'TRANSACTION_TYPES' => [],
+        ]);
+    }
+
+
+    /**
+     * hashSignedTx() produces the hashed blob itself when given an array, so
+     * the definitions decide the result. Getting this wrong yields a valid
+     * looking but wrong hash, with nothing to indicate it.
+     */
+    public function testHashSignedTxHonoursDefinitions(): void
+    {
+        $wallet = Wallet::fromSeed(self::SEED);
+
+        $tx = self::payment();
+        $tx['Account'] = $wallet->getAddress();
+        $signed = $wallet->sign($tx);
+        $txObject = (new BinaryCodec())->decode($signed['tx_blob']);
+
+        $default = HashLedger::hashSignedTx($txObject);
+        $custom = HashLedger::hashSignedTx($txObject, self::alternativeDefinitions());
+
+        $this->assertEquals($signed['hash'], $default);
+        $this->assertNotEquals($default, $custom, 'other definitions have to produce a different blob');
+    }
+
+    /**
+     * Definitions with a field the bundled set does not know, the way a Xahau
+     * specific field behaves.
+     */
+    private static function definitionsWithExtraField(): Definitions
+    {
+        $raw = json_decode(file_get_contents(self::DEFINITIONS_PATH), true);
+        $raw['FIELDS'][] = ['NetworkSpecificBlob', [
+            'nth' => 32,
+            'isVLEncoded' => true,
+            'isSerialized' => true,
+            'isSigningField' => true,
+            'type' => 'Blob',
+        ]];
+
+        return Definitions::fromArray($raw);
+    }
+
+    /**
+     * Wallet::sign() hashes the blob it just produced. Hashing decodes it to
+     * check the signature is present, and decoding resolves every field - so a
+     * transaction carrying a field only the injected definitions know would
+     * throw there if the wallet hashed through the default set instead.
+     */
+    public function testWalletSignsTransactionWithNetworkSpecificField(): void
+    {
+        $definitions = self::definitionsWithExtraField();
+        $wallet = Wallet::fromSeed(self::SEED, $definitions);
+
+        $tx = self::payment();
+        $tx['Account'] = $wallet->getAddress();
+        $tx['NetworkSpecificBlob'] = 'DEADBEEF';
+
+        $signed = $wallet->sign($tx);
+
+        $this->assertTrue($wallet->verifyTransaction($signed['tx_blob']));
+        $this->assertEquals(
+            'DEADBEEF',
+            (new BinaryCodec($definitions))->decode($signed['tx_blob'])['NetworkSpecificBlob']
+        );
+
+        // The bundled definitions cannot read that field at all
+        $this->expectException(Exception::class);
+        (new BinaryCodec())->decode($signed['tx_blob']);
+    }
+
+    /**
+     * Decoding resolves every field in the blob, so these helpers need the
+     * definitions the transaction was built with - not just for the field they
+     * read, but to get through the decode at all.
+     */
+    public function testSugarHelpersAcceptDefinitions(): void
+    {
+        $definitions = self::alternativeDefinitions();
+        $tx = self::payment();
+        $tx['LastLedgerSequence'] = 4321;
+        $blob = (new BinaryCodec($definitions))->encode(json_encode($tx));
+
+        $this->assertEquals(4321, getLastLedgerSequence($blob, $definitions));
+        $this->assertFalse(isAccountDelete($blob, $definitions));
+    }
+}


### PR DESCRIPTION
## Summary

Prepares the ground for a separate Xahau package by letting the codec work against definitions handed in from outside.

2.0.0 documented that Xahau support is broken for 23 transaction types but could not fix it: the two networks assign different ordinals to the types they share, so a single merged definitions set is wrong for one side no matter which
way the merge resolves. `MPTokenIssuanceCreate` is **54** on the XRP Ledger and **63** on Xahau; of the 59 shared types only 36 line up.

This PR does not fix Xahau — it makes fixing it possible from outside:

```php
$definitions = Definitions::fromFile('xahau-definitions.json');

$codec  = new BinaryCodec($definitions);
$wallet = Wallet::fromSeed($seed, $definitions);
$client = new JsonRpcClient($url, null, null, 3.0, $definitions);
```

Verified against the live Xahau node's own server_definitions: the same transaction encodes to ordinal 54 with the bundled definitions and 63 with Xahau's, and both signatures verify.

### Why not a Network enum

Because it would put a second network's concept into the public API of a library that is otherwise entirely about the XRP Ledger — Wallet::fromSeed() would grow a network parameter that most callers never touch. Handing in a Definitions instance keeps the seam internal and works for any network, not just Xahau. When the Xahau types eventually leave this library, nothing in the API has to change back.

### Scope

Smaller than it first looked. Only two serialized types resolve field names, so only those two needed a parameter:

|  Touched | Untouched |
| --- | --- |
| Definitions, BinaryParser, Binary/BinaryCodec, StObject, StArray, Wallet, JsonRpcClient, HashLedger, two Sugar helpers  | The other 27 serialized types — Amount, Blob, AccountId, all Hash*/UInt*, Issue, PathSet, Vector256, Number ... |

BinaryParser carries the definitions through the decode, so fromParser() needed no signature change anywhere. StObject and StArray keep them on the parsed instance so that toJson() resolves names against the same set.

No breaking changes. Every new parameter is optional and falls back to the bundled XRP Ledger definitions.

### Fixed along the way

- Wallet::sign() hashed through the wrong definitions. It encoded against the wallet's set but handed the blob to HashLedger, which used the default one. Hashing decodes the blob to check a signature is present, and decoding resolves every field — so a transaction with a field only the injected definitions know threw inside sign().
- HashLedger::hashSignedTx() can return a silently wrong hash. Given an array it encodes the blob that then gets hashed, so the definitions decide the result. The string path is unaffected, since there the hash comes from the input blob.
- Sugar\getLastLedgerSequence() and Sugar\isAccountDelete() decode a whole blob to read one field. My first assessment called this harmless because those ordinals match across networks — that misses that the decode has to resolve every other field first. Both now take the definitions too.

### Tests

11 new tests in InjectableDefinitionsTest, covering encode, decode, nested objects, wallet signing, hashing, and that an injected set does not leak into the shared default instance.

The alternative definitions are built by remapping ordinals in the bundled set rather than checking in a second large fixture — that reproduces exactly what makes the networks incompatible, without a network dependency in the suite.

One note on test quality: the first version of the hashing test compared two hashes over the string path, where the hash is definitions-independent by construction. It would have passed without the fix. It is replaced by one that uses a field only the injected definitions know, and I verified it fails at Wallet.php:152 → HashLedger.php:50 when the fix is reverted.

550 tests green.

### Not covered

- The bundled definitions still merge the Xahau ones, so 2.x behaves as before for anyone not injecting their own set. The Xahau types leave in 3.0.0, once the separate package exists.
- HashLedger remains a singleton; hashSignedTx() builds a codec on demand when definitions are passed rather than restructuring it. Untangling the singleton belongs with the wider cleanup.